### PR TITLE
Fix extools dynamic call syntax

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -477,7 +477,7 @@ var/world_topic_spam_protect_time = world.timeofday
 /world/Del()
 	callHook("shutdown")
 	if(fexists("byond-extools.dll"))
-		call("byond-extools.dll", "cleanup")
+		call("byond-extools.dll", "cleanup")()
 	return
 
 /hook/startup/proc/loadMode()

--- a/code/modules/extools/socket.dm
+++ b/code/modules/extools/socket.dm
@@ -27,7 +27,7 @@
 /datum/socket/proc/close()
 
 /world/proc/enable_sockets()
-	call("byond-extools.dll", "init_sockets")
+	call("byond-extools.dll", "init_sockets")()
 
 /* Example:
 


### PR DESCRIPTION
## Summary
- ensure extools cleanup and init functions are invoked

## Testing
- `DreamMaker InterHippie.dme` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2392fbd8c832bb7d6d8454cf280c8